### PR TITLE
chore: add support for Maven 3.5.4 and 3.6.2 in lib/common.sh

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export DEFAULT_MAVEN_VERSION="3.3.9"
+export DEFAULT_MAVEN_VERSION="3.6.2"
 export BUILDPACK_STDLIB_URL="https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh"
 
 install_maven() {
@@ -37,6 +37,12 @@ download_maven() {
 is_supported_maven_version() {
   local mavenVersion=${1}
   if [ "$mavenVersion" = "$DEFAULT_MAVEN_VERSION" ]; then
+    return 0
+  elif [ "$mavenVersion" = "3.6.2" ]; then
+    return 0
+  elif [ "$mavenVersion" = "3.5.4" ]; then
+    return 0
+  elif [ "$mavenVersion" = "3.3.9" ]; then
     return 0
   elif [ "$mavenVersion" = "3.2.5" ]; then
     return 0

--- a/vendor/maven/sources.txt
+++ b/vendor/maven/sources.txt
@@ -5,5 +5,3 @@ https://apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.
 https://apache.org/dist/maven/maven-3/3.3.1/binaries/apache-maven-3.3.1-bin.tar.gz
 https://apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
 https://apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
-https://apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
-https://apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz

--- a/vendor/maven/sources.txt
+++ b/vendor/maven/sources.txt
@@ -5,3 +5,5 @@ https://apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.
 https://apache.org/dist/maven/maven-3/3.3.1/binaries/apache-maven-3.3.1-bin.tar.gz
 https://apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
 https://apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+https://apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
+https://apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz


### PR DESCRIPTION
Tested on [test-java-buildpack](https://my.osc-fr1.scalingo.com/apps/test-java-buildpack/containers) and it works.
Excerpt from the deployment logs:

```
-----> Installing Maven 3.6.2... done
```

Replace #6