### PR TITLE
fix: initialize BUILDPACK_DEBUG var to empty string

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+BUILDPACK_DEBUG="${BUILDPACK_DEBUG:-}"
+
 set -euo pipefail
 
 if [[ -n "$BUILDPACK_DEBUG" ]]; then


### PR DESCRIPTION
This will prevent this error : 
BUILDPACK_DEBUG: unbound variable