### PR TITLE
fix: use Scalingo's jvm-common to install OpenJDK

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -96,9 +96,15 @@ common::install_jdk() {
 	local install_dir="${1}"
 	local cache_dir="${2}"
 
-	JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz}
+	JVM_COMMON_BUILDPACK="${JVM_COMMON_BUILDPACK:-"https://buildpacks-repository.s3.eu-central-1.amazonaws.com/jvm-common.tar.xz"}"
+
 	mkdir -p /tmp/jvm-common
-	curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --location "${JVM_COMMON_BUILDPACK}" | tar xzm -C /tmp/jvm-common --strip-components=1
+
+	curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent \
+		--location "${JVM_COMMON_BUILDPACK}" \
+		| tar --extract --xz --touch --directory="/tmp/jvm-common" \
+			--strip-components=1
+
 	#shellcheck source=/dev/null
 	source /tmp/jvm-common/bin/java
 	#shellcheck source=/dev/null


### PR DESCRIPTION
Fix #30 
Following https://github.com/Scalingo/buildpack-jvm-common/pull/61

Tested here: https://fku-java-spark.osc-st-fr1.apps.st-sc.fr/